### PR TITLE
Fix Background Image

### DIFF
--- a/character.yaml
+++ b/character.yaml
@@ -1,0 +1,5 @@
+﻿singer_type: diffsinger
+text_file_encoding: utf-8
+portrait: yousa-background.png
+portrait_opacity: 0.67
+default_phonemizer: OpenUtau.Core.DiffSinger.DiffsingerMandarinPhonemizer


### PR DESCRIPTION
替换背景图片（原背景图片在dark主题下会存在问题

替换前
![before](https://github.com/yousa-ling-official-production/yousa-ling-diffsinger-v1/assets/47050377/827538fa-00a3-4a3b-afde-f99f85fe7979)
替换后
![afterfix](https://github.com/yousa-ling-official-production/yousa-ling-diffsinger-v1/assets/47050377/13e0be31-de2d-46e7-99b5-457ac45d5ac3)
