### PR TITLE
Fix Background

### DIFF
--- a/character.yaml
+++ b/character.yaml
@@ -1,0 +1,5 @@
+﻿singer_type: diffsinger
+text_file_encoding: utf-8
+portrait: yousa-background.png
+portrait_opacity: 0.67
+default_phonemizer: OpenUtau.Core.DiffSinger.DiffsingerMandarinPhonemizer


### PR DESCRIPTION
替换背景图片
原本的图片不带Alpha通道 dark模式下看起来会怪怪的
![before](https://github.com/yousa-ling-official-production/yousa-ling-diffsinger-v1/assets/47050377/497c0285-2ef4-4f13-b885-7a4425aeb09d)
于是花了几分钟扣了一下
![afterfix](https://github.com/yousa-ling-official-production/yousa-ling-diffsinger-v1/assets/47050377/da4f1f7b-c95c-4007-8126-f2bd71e296f0)
